### PR TITLE
Add support for BP5360 / HEM-7377T1-ZAZ (+ Linux scan-during-connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This is most important when you are trying to add support for a new device.
 | [HEM-7342T](deviceSpecific/hem-7342t.py) | BP7450                           | ✔️ | ✔️ | ❓  | ❓ | Toei79, userx14           |
 | [HEM-7361T](deviceSpecific/hem-7361t.py) | M500 Intelli IT / M7 Intelli IT 	| ✔️ | ✔️ | ✔️ | ✔️ | LazyT, userx14, zivanfi, RobertWojtowicz |
 | [HEM-7380T1](deviceSpecific/hem-7380t1.py) | X7 Smart AFib / M7 Intelli IT AFib / EOSL / EBK | n/a | ✔️ | ❌ | ❌ | thiagoko |
+| [HEM-7377T1](deviceSpecific/hem-7377t1.py) | BP5360                           | n/a | ✔️ | ❌ | ✔️ | ojermo |
 | [HEM-7530T](deviceSpecific/hem-7530t.py) | Omron Complete                   | ✔️ | ✔️ (no EKG) | ❌ | ❌ | Toei79, userx14  |
 | [HEM-7600T](deviceSpecific/hem-7600t.py) | Omron Evolv 				      	      | ✔️ | ✔️ | ✔️ | ✔️ | vulcainman 				        |
 | [HEM-6232T](deviceSpecific/hem-6232T.py) | RS7 Intelli IT			      	      | ✔️ | ✔️ | ❓ | ❓ |  invertedburger				        |

--- a/deviceSpecific/hem-7377t1.py
+++ b/deviceSpecific/hem-7377t1.py
@@ -32,13 +32,14 @@ class deviceSpecificDriver(sharedDeviceDriverCode):
     supportsOsBondingOnly      = True
 
     deviceEndianess            = "little"
-    # Two user record slots, matching the HEM-7380T1 layout. NOTE: the slot
-    # index here ("user 1" = first list element, "user 2" = second) may NOT
-    # match the user labels on the cuff display. Empirically on one BP5360
-    # sample, all of one user's measurements landed in slot index 1 (0x080C),
-    # while slot index 0 (0x01CC) and probed addresses 0x0098 and 0x0E4C were
-    # empty. Recommend: take a known measurement in each cuff user mode
-    # (Guest / User 1 / User 2) and verify which CSV it lands in.
+    # Two record slots; matches HEM-7380T1 layout. NOTE on user identification:
+    # the cuff stores BOTH "User 1" and "User 2" measurements in slot index 1
+    # (0x080C); they are distinguished by metadata bytes within the record
+    # itself. byte 13 is consistently 0x01 for User 1 records, 0xFF for User 2
+    # records. Bytes 8-15 hold structured metadata for User 1 (sequence
+    # counter at byte 9, etc.) and are all-FF for User 2. Guest measurements
+    # are not stored to EEPROM at all (verified empirically). The slot at
+    # 0x01CC is reserved but appears unused on the BP5360 sample tested.
     userStartAdressesList      = [0x01CC, 0x080C]
     perUserRecordsCountList    = [100, 100]
     recordByteSize             = 0x10

--- a/deviceSpecific/hem-7377t1.py
+++ b/deviceSpecific/hem-7377t1.py
@@ -1,0 +1,75 @@
+import datetime
+import logging
+import sys
+
+logger = logging.getLogger("omblepy")
+
+sys.path.append('..')
+from sharedDriver import sharedDeviceDriverCode
+
+
+class deviceSpecificDriver(sharedDeviceDriverCode):
+    """Driver for Omron BP5360 (HEM-7377T1-ZAZ).
+
+    Same Omron HEM-7361T-family record format and same vendor service UUIDs
+    as HEM-7380T1, but with a different memory layout (record area starts
+    8 bytes into the user data region — a header precedes the records).
+
+    Authentication: OS-managed BLE bond only. The device does NOT respond to
+    omblepy's 0x02/0x00/0x01 key programming flow at all (verified across 20+
+    attempts with various orderings). Pair through the OS BLE stack first
+    (bluetoothctl on Linux, Settings on Windows), then read with this driver.
+
+    Time sync: requires a non-obvious byte-14 counter increment quirk at
+    EEPROM 0x0088 (returning 0xe5 / "Err" otherwise). Not implemented in this
+    driver yet — run without -t / --timeSync. See PR description for details.
+    """
+    parentService_UUID         = "0000fe4a-0000-1000-8000-00805f9b34fb"
+    deviceRxChannelUUIDs       = ["49123040-aee8-11e1-a74d-0002a5d5c51b"]
+    deviceTxChannelUUIDs       = ["db5b55e0-aee7-11e1-965e-0002a5d5c51b"]
+    requiresUnlock             = False
+    supportsPairing            = False
+    supportsOsBondingOnly      = True
+
+    deviceEndianess            = "little"
+    # Two user record slots, matching the HEM-7380T1 layout. NOTE: the slot
+    # index here ("user 1" = first list element, "user 2" = second) may NOT
+    # match the user labels on the cuff display. Empirically on one BP5360
+    # sample, all of one user's measurements landed in slot index 1 (0x080C),
+    # while slot index 0 (0x01CC) and probed addresses 0x0098 and 0x0E4C were
+    # empty. Recommend: take a known measurement in each cuff user mode
+    # (Guest / User 1 / User 2) and verify which CSV it lands in.
+    userStartAdressesList      = [0x01CC, 0x080C]
+    perUserRecordsCountList    = [100, 100]
+    recordByteSize             = 0x10
+    transmissionBlockSize      = 0x38
+
+    settingsReadAddress        = None
+    settingsWriteAddress       = None
+    settingsUnreadRecordsBytes = None
+    settingsTimeSyncBytes      = None
+
+    def deviceSpecific_ParseRecordFormat(self, singleRecordAsByteArray):
+        # HEM-7361T-family bit layout (BP5360 uses the same record format).
+        recordDict = dict()
+        minute = self._bytearrayBitsToInt(singleRecordAsByteArray, 68, 73)
+        second = self._bytearrayBitsToInt(singleRecordAsByteArray, 74, 79)
+        second = min([second, 59])  # field can range up to 63 in some records
+        recordDict["mov"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 80, 80)
+        recordDict["ihb"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 81, 81)
+        month = self._bytearrayBitsToInt(singleRecordAsByteArray, 82, 85)
+        day = self._bytearrayBitsToInt(singleRecordAsByteArray, 86, 90)
+        hour = self._bytearrayBitsToInt(singleRecordAsByteArray, 91, 95)
+        year = self._bytearrayBitsToInt(singleRecordAsByteArray, 98, 103) + 2000
+        recordDict["bpm"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 104, 111)
+        recordDict["dia"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 112, 119)
+        recordDict["sys"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 120, 127) + 25
+        recordDict["datetime"] = datetime.datetime(year, month, day, hour, minute, second)
+        return recordDict
+
+    def deviceSpecific_syncWithSystemTime(self):
+        raise ValueError(
+            "BP5360 time sync requires a byte-14 counter increment quirk that "
+            "isn't yet integrated into omblepy's settings-cache flow. "
+            "Re-run without -t / --timeSync."
+        )

--- a/deviceSpecific/hem-7377t1.py
+++ b/deviceSpecific/hem-7377t1.py
@@ -44,32 +44,81 @@ class deviceSpecificDriver(sharedDeviceDriverCode):
     recordByteSize             = 0x10
     transmissionBlockSize      = 0x38
 
-    settingsReadAddress        = None
-    settingsWriteAddress       = None
-    settingsUnreadRecordsBytes = None
-    settingsTimeSyncBytes      = None
+    # Settings region: time data lives in the first 16 bytes of a 0x18-byte
+    # status block at 0x0040, and the time-sync write target is 0x0088.
+    # (settingsUnreadRecordsBytes is set to a zero-length range because BP5360's
+    # unread-record counter location isn't yet mapped — --newRecOnly will
+    # behave as if no records are unread until that's investigated.)
+    settingsReadAddress        = 0x0040
+    settingsWriteAddress       = 0x0088
+    settingsUnreadRecordsBytes = [0x00, 0x00]
+    settingsTimeSyncBytes      = [0x00, 0x10]
 
     def deviceSpecific_ParseRecordFormat(self, singleRecordAsByteArray):
         # HEM-7361T-family bit layout (BP5360 uses the same record format).
-        recordDict = dict()
-        minute = self._bytearrayBitsToInt(singleRecordAsByteArray, 68, 73)
-        second = self._bytearrayBitsToInt(singleRecordAsByteArray, 74, 79)
-        second = min([second, 59])  # field can range up to 63 in some records
-        recordDict["mov"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 80, 80)
-        recordDict["ihb"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 81, 81)
+        # Detect empty / non-record slots up front to keep omblepy's parse-error
+        # warnings clean: BP5360's unused user slot contains daily-summary or
+        # similar metadata that decodes to nonsense dates if pushed through the
+        # full parser.
+        year = self._bytearrayBitsToInt(singleRecordAsByteArray, 98, 103) + 2000
+        if year < 2020:
+            raise ValueError("record slot is empty")
         month = self._bytearrayBitsToInt(singleRecordAsByteArray, 82, 85)
         day = self._bytearrayBitsToInt(singleRecordAsByteArray, 86, 90)
         hour = self._bytearrayBitsToInt(singleRecordAsByteArray, 91, 95)
-        year = self._bytearrayBitsToInt(singleRecordAsByteArray, 98, 103) + 2000
+        minute = self._bytearrayBitsToInt(singleRecordAsByteArray, 68, 73)
+        if not (1 <= month <= 12) or not (1 <= day <= 31) or hour > 23 or minute > 59:
+            raise ValueError("record slot is empty")
+
+        second = self._bytearrayBitsToInt(singleRecordAsByteArray, 74, 79)
+        second = min([second, 59])  # field can range up to 63 in some records
+
+        recordDict = dict()
+        recordDict["mov"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 80, 80)
+        recordDict["ihb"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 81, 81)
         recordDict["bpm"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 104, 111)
         recordDict["dia"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 112, 119)
         recordDict["sys"] = self._bytearrayBitsToInt(singleRecordAsByteArray, 120, 127) + 25
+
+        # Range sanity (matches the standalone implementation; defends against
+        # rare corruption of stored records).
+        if not (60 <= recordDict["sys"] <= 250) or not (30 <= recordDict["dia"] <= 150) or not (30 <= recordDict["bpm"] <= 200):
+            raise ValueError("record values out of physiological range")
+
         recordDict["datetime"] = datetime.datetime(year, month, day, hour, minute, second)
         return recordDict
 
     def deviceSpecific_syncWithSystemTime(self):
-        raise ValueError(
-            "BP5360 time sync requires a byte-14 counter increment quirk that "
-            "isn't yet integrated into omblepy's settings-cache flow. "
-            "Re-run without -t / --timeSync."
-        )
+        # BP5360 byte-14 turns out to be a CHECKSUM of bytes 0-13 (sum & 0xff),
+        # the same convention HEM-7361T uses. The "running counter" formula in
+        # the original reverse engineering — old_byte14 + (new_sec - old_sec) + 1
+        # — was a coincidence: when only the second byte changes by +N (and
+        # byte 4 changes from 0x00 to 0x01), the checksum delta IS exactly
+        # N + 1, so the additive formula matched in the common case. It breaks
+        # when seconds wrap (negative delta) or when other date bytes change.
+        # Computing the checksum directly works in all cases.
+        timeSyncSettingsCopy = self.cachedSettingsBytes[slice(*self.settingsTimeSyncBytes)]
+        old_byte14 = timeSyncSettingsCopy[14]
+
+        currentTime = datetime.datetime.now()
+
+        # Build the new time block. Bytes 0-7 are preserved from the device read;
+        # byte 4 is forced to 0x01 (required by BP5360 firmware — purpose unclear
+        # from reverse engineering, but consistently sent by the Android app).
+        setNewTimeDataBytes = bytearray(timeSyncSettingsCopy[0:8])
+        setNewTimeDataBytes[4] = 0x01
+        setNewTimeDataBytes += bytes([
+            currentTime.year - 2000,
+            currentTime.month,
+            currentTime.day,
+            currentTime.hour,
+            currentTime.minute,
+            currentTime.second,
+        ])
+        # byte 14 = checksum over bytes 0-13; byte 15 = 0
+        checksum = sum(setNewTimeDataBytes) & 0xFF
+        setNewTimeDataBytes += bytes([checksum, 0x00])
+
+        self.cachedSettingsBytes[slice(*self.settingsTimeSyncBytes)] = setNewTimeDataBytes
+        logger.info(f"BP5360 time set to {currentTime.strftime('%Y-%m-%d %H:%M:%S')} "
+                    f"(byte14 checksum: 0x{old_byte14:02x} -> 0x{checksum:02x})")

--- a/omblepy.py
+++ b/omblepy.py
@@ -404,7 +404,46 @@ async def main():
         print(" -do not accept any pairing dialog until you selected your device in the following list\n")
         bleAddr = await selectBLEdevices()
 
-    bleClient = bleak.BleakClient(bleAddr)
+    # Linux/BlueZ workaround: BleakClient(MAC).connect() can time out even
+    # when the device is advertising, because BlueZ's standard Connect path
+    # doesn't keep the radio actively receiving for the device. Running an
+    # active BleakScanner in parallel keeps BlueZ in receive mode, so it acts
+    # on the next advertising packet immediately. Verified empirically against
+    # an Omron BP5360 advertising every ~1.7s. Scanner is stopped in finally.
+    #
+    # Multi-adapter Linux machines also need an explicit adapter pin: BlueZ
+    # scopes the device record to whichever adapter discovered it, and a
+    # subsequent connect on a different adapter no-ops silently. We extract
+    # the adapter from the BLEDevice's BlueZ path after detection.
+    scanner = None
+    if sys.platform == "linux":
+        logger.debug("Linux: pre-scanning to keep BlueZ in receive mode for connect.")
+        found_device_holder = [None]
+        found_event = asyncio.Event()
+        def _detection_cb(device, _adv_data):
+            if device.address.upper() == bleAddr.upper() and not found_device_holder[0]:
+                found_device_holder[0] = device
+                found_event.set()
+        scanner = bleak.BleakScanner(detection_callback=_detection_cb, scanning_mode="active", bluez={"adapter": "hci1"})  # TODO: derive from CLI arg or auto-discover
+        await scanner.start()
+        try:
+            await asyncio.wait_for(found_event.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            await scanner.stop()
+            raise OSError(f"Device {bleAddr} not advertising within 30s. Verify it's in range and powered.")
+        # Extract adapter from BlueZ device path (e.g. /org/bluez/hci1/dev_...)
+        adapter_name = None
+        details = getattr(found_device_holder[0], "details", None)
+        if isinstance(details, dict):
+            path = details.get("path") or details.get("props", {}).get("Adapter")
+            if isinstance(path, str) and "/hci" in path:
+                adapter_name = path.split("/")[3] if path.startswith("/org/bluez/") else None
+        client_kwargs = {"bluez": {"adapter": adapter_name}} if adapter_name else {}
+        logger.debug(f"Connecting via adapter: {adapter_name or 'default'}")
+        bleClient = bleak.BleakClient(found_device_holder[0], **client_kwargs)
+    else:
+        bleClient = bleak.BleakClient(bleAddr)
+
     try:
         logger.info(f"Attempt connecting to {bleAddr}.")
         await bleClient.connect()
@@ -451,5 +490,10 @@ async def main():
                 logger.error("Bleak AssertionError during disconnect. This usually happens when using the bluezdbus adapter.")
                 logger.error("You can find the upstream issue at: https://github.com/hbldh/bleak/issues/641")
                 logger.error(f"AssertionError details: {e}")
+        if scanner is not None:
+            try:
+                await scanner.stop()
+            except Exception as e:
+                logger.debug(f"Scanner stop raised (ignored): {e}")
 
 asyncio.run(main())

--- a/omblepy.py
+++ b/omblepy.py
@@ -353,6 +353,7 @@ async def main():
     parser.add_argument('-n', "--newRecOnly", action="store_true",          help="Considers the unread records counter and only reads new records. Resets these counters afterwards. If not enabled, all records are read and the unread counters are not cleared.")
     parser.add_argument('-t', "--timeSync",   action="store_true",          help="Update the time on the omron device by using the current system time.")
     parser.add_argument('-k', "--key",                          type=str,   help="Pairing key as a 32-character hex-string (e.g. 0123456789abcdef0123456789abcdef). If not specified, uses default key.")
+    parser.add_argument("--adapter",                            type=str,   help="Linux/BlueZ only: specify which BT adapter to use (e.g. hci0, hci1). Defaults to whatever BlueZ picks; needed on multi-adapter systems if the cuff is bonded on a non-default adapter.")
     args = parser.parse_args()
 
     #setup logging
@@ -424,7 +425,10 @@ async def main():
             if device.address.upper() == bleAddr.upper() and not found_device_holder[0]:
                 found_device_holder[0] = device
                 found_event.set()
-        scanner = bleak.BleakScanner(detection_callback=_detection_cb, scanning_mode="active", bluez={"adapter": "hci1"})  # TODO: derive from CLI arg or auto-discover
+        scanner_kwargs = {}
+        if args.adapter:
+            scanner_kwargs["bluez"] = {"adapter": args.adapter}
+        scanner = bleak.BleakScanner(detection_callback=_detection_cb, scanning_mode="active", **scanner_kwargs)
         await scanner.start()
         try:
             await asyncio.wait_for(found_event.wait(), timeout=30)


### PR DESCRIPTION
Implements BP5360 (HEM-7377T1-ZAZ) support discussed in [#67](https://github.com/userx14/omblepy/issues/67).
  
Five commits, separable for review:
  
- `f049488` — Device driver (`deviceSpecific/hem-7377t1.py`) + Linux scan-during-connect block in `omblepy.py main()`
- `152c907` — Empty-slot detection + time sync (byte-14 checksum, matches HEM-7361T's convention)
- `384ac31` — `--adapter` CLI flag for multi-adapter Linux setups 
- `1635fd1` — Driver docstring update with the empirical user-ID finding (byte 13: 0x01 = User 1, 0xFF = User 2)
- `16318b0` — README device support matrix entry
  
See [#67](https://github.com/userx14/omblepy/issues/67) for the protocol notes (byte-14 checksum, pair-mode-only "okay"/"Err" display behavior, guest-not-stored, user-ID encoding) and the Linux scan-during-connect rationale.
  
Happy to split the Linux scan-during-connect change into its own PR if you'd prefer to review it separately from the BP5360 driver.
