### PR TITLE
Add Omron BP4350 support (standard pairing + BlueZ SMP agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ This is most important when you are trying to add support for a new device.
 | [HEM-7530T](deviceSpecific/hem-7530t.py) | Omron Complete                   | ✔️ | ✔️ (no EKG) | ❌ | ❌ | Toei79, userx14  |
 | [HEM-7600T](deviceSpecific/hem-7600t.py) | Omron Evolv 				      	      | ✔️ | ✔️ | ✔️ | ✔️ | vulcainman 				        |
 | [HEM-6232T](deviceSpecific/hem-6232T.py) | RS7 Intelli IT			      	      | ✔️ | ✔️ | ❓ | ❓ |  invertedburger				        |
+| [BP4350](deviceSpecific/bp4350.py)       | BP4350 (Gold Wrist / HEM-6232T-Z), alias of HEM-6232T | ✔️ | ✔️ | ❓ | ❓ | nullvariable                      |
 | HEM-7196T | M4/X4 Connect AFib			      	      | ❌ (encrypted traffic) | ❌ (encrypted, see issues) | ❌ | ❌ | |
 
 ✔️=tested working, ❓=not tested , ❌=not supported yet <br>
+
+**Note (BP4350):** The BP4350 is the US-market HEM-6232T-Z and uses the HEM-6232T driver unchanged. Despite advertising OMSEC service UUIDs in its GATT table, it follows the same standard unlock-key pairing flow as other omblepy devices, but requires an active BLE bond (SMP pairing) before the key programming flow will succeed. On Linux, pass `--bond` together with `-p` to let omblepy create the bond automatically via a BlueZ NoInputNoOutput agent (uses `dbus-fast`); alternatively, bond the device in your OS bluetooth settings before pairing. Pairing on Windows/macOS is untested.
 
 Please open an issue if you can test a feature or an currently unsupported device. <br>
 It is potentially dangerous to write to the eeprom on devices where the eeprom layout is unknown (see Flags table), <br>

--- a/bluez_linux.py
+++ b/bluez_linux.py
@@ -1,0 +1,202 @@
+"""
+Linux/BlueZ specific helper functions for omblepy.
+
+Everything in this file talks to BlueZ, either through bleak or directly
+via D-Bus. Callers must confirm the operating system is Linux before
+calling any function in this module.
+"""
+
+import asyncio
+import logging
+
+import bleak
+
+logger = logging.getLogger("omblepy")
+
+_SMP_AGENT_PATH = "/omblepy/smp_agent"
+
+
+async def register_smp_agent():
+    """Register a NoInputNoOutput BlueZ pairing agent via D-Bus.
+    Returns the MessageBus instance (for cleanup), or None on failure."""
+    try:
+        from dbus_fast.aio import MessageBus
+        from dbus_fast.constants import BusType
+        from dbus_fast.service import ServiceInterface, method
+    except ImportError:
+        logger.warning("dbus-fast not installed, SMP agent not available.")
+        return None
+
+    class SmpAgent(ServiceInterface):
+        """BlueZ pairing agent that accepts all pairing requests."""
+        def __init__(self):
+            super().__init__("org.bluez.Agent1")
+
+        @method()
+        def Release(self): pass
+
+        @method()
+        def RequestPinCode(self, device: "o") -> "s":
+            logger.debug(f"SMP Agent: PinCode requested for {device}")
+            return "000000"
+
+        @method()
+        def DisplayPinCode(self, device: "o", pincode: "s"):
+            logger.debug(f"SMP Agent: DisplayPinCode {pincode}")
+
+        @method()
+        def RequestPasskey(self, device: "o") -> "u":
+            logger.debug(f"SMP Agent: Passkey requested for {device}")
+            return 0
+
+        @method()
+        def DisplayPasskey(self, device: "o", passkey: "u", entered: "q"):
+            logger.debug(f"SMP Agent: DisplayPasskey {passkey:06d}")
+
+        @method()
+        def RequestConfirmation(self, device: "o", passkey: "u"):
+            logger.debug(f"SMP Agent: Confirm passkey {passkey:06d}")
+
+        @method()
+        def RequestAuthorization(self, device: "o"):
+            logger.debug(f"SMP Agent: Authorization requested")
+
+        @method()
+        def AuthorizeService(self, device: "o", uuid: "s"):
+            logger.debug(f"SMP Agent: AuthorizeService {uuid}")
+
+        @method()
+        def Cancel(self):
+            logger.debug("SMP Agent: Cancelled")
+
+    try:
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        agent = SmpAgent()
+        bus.export(_SMP_AGENT_PATH, agent)
+
+        intro = await bus.introspect("org.bluez", "/org/bluez")
+        proxy = bus.get_proxy_object("org.bluez", "/org/bluez", intro)
+        agent_mgr = proxy.get_interface("org.bluez.AgentManager1")
+
+        try:
+            await agent_mgr.call_unregister_agent(_SMP_AGENT_PATH)
+        except Exception:
+            pass
+
+        await agent_mgr.call_register_agent(_SMP_AGENT_PATH, "NoInputNoOutput")
+        await agent_mgr.call_request_default_agent(_SMP_AGENT_PATH)
+
+        logger.info("SMP agent registered (NoInputNoOutput)")
+        return bus
+    except Exception as e:
+        logger.warning(f"Failed to register SMP agent: {e}")
+        return None
+
+
+async def find_device_dbus_path(bus, address):
+    """Locate the BlueZ D-Bus object path for a device address, across all adapters."""
+    pathSuffix = "dev_" + address.replace(":", "_").upper()
+    intro = await bus.introspect("org.bluez", "/")
+    proxy = bus.get_proxy_object("org.bluez", "/", intro)
+    obj_mgr = proxy.get_interface("org.freedesktop.DBus.ObjectManager")
+    managedObjects = await obj_mgr.call_get_managed_objects()
+    for path, interfaces in managedObjects.items():
+        if path.endswith(pathSuffix) and "org.bluez.Device1" in interfaces:
+            return path
+    return None
+
+
+async def perform_smp_pairing(bus, address):
+    """Perform SMP pairing via D-Bus for the connected device with the given address."""
+    try:
+        dev_path = await find_device_dbus_path(bus, address)
+        if dev_path is None:
+            logger.warning(f"Device {address} not found on BlueZ D-Bus object tree, skipping SMP pairing step")
+            return
+
+        intro = await bus.introspect("org.bluez", dev_path)
+        proxy = bus.get_proxy_object("org.bluez", dev_path, intro)
+        dev_props = proxy.get_interface("org.freedesktop.DBus.Properties")
+        dev_iface = proxy.get_interface("org.bluez.Device1")
+
+        paired = await dev_props.call_get("org.bluez.Device1", "Paired")
+        if paired.value:
+            logger.info("Device already SMP paired")
+            return
+
+        logger.info("Performing SMP pairing...")
+        await asyncio.wait_for(dev_iface.call_pair(), timeout=15.0)
+
+        paired = await dev_props.call_get("org.bluez.Device1", "Paired")
+        if paired.value:
+            logger.info("SMP pairing successful")
+        else:
+            logger.warning("SMP pairing returned but device not paired")
+
+        # Trust the device
+        from dbus_fast import Variant
+        await dev_props.call_set("org.bluez.Device1", "Trusted", Variant("b", True))
+
+    except asyncio.TimeoutError:
+        logger.warning("SMP pairing timed out (may still be OK)")
+    except Exception as e:
+        if "AlreadyExists" in str(e):
+            logger.info("Device already paired")
+        else:
+            logger.warning(f"SMP pairing error: {e}")
+
+
+async def unregister_smp_agent(bus):
+    """Unregister the SMP agent and disconnect the D-Bus connection."""
+    try:
+        intro = await bus.introspect("org.bluez", "/org/bluez")
+        proxy = bus.get_proxy_object("org.bluez", "/org/bluez", intro)
+        agent_mgr = proxy.get_interface("org.bluez.AgentManager1")
+        await agent_mgr.call_unregister_agent(_SMP_AGENT_PATH)
+    except Exception:
+        pass
+    bus.disconnect()
+
+
+async def find_device_with_active_scan(bleAddr, adapter=None, timeoutS=30):
+    """Linux/BlueZ workaround: BleakClient(MAC).connect() can time out even
+    when the device is advertising, because BlueZ's standard Connect path
+    doesn't keep the radio actively receiving for the device. Running an
+    active BleakScanner in parallel keeps BlueZ in receive mode, so it acts
+    on the next advertising packet immediately. Verified empirically against
+    an Omron BP5360 advertising every ~1.7s.
+
+    Multi-adapter Linux machines also need an explicit adapter pin: BlueZ
+    scopes the device record to whichever adapter discovered it, and a
+    subsequent connect on a different adapter no-ops silently. We extract
+    the adapter from the BLEDevice's BlueZ path after detection.
+
+    Returns (bleDevice, adapterName, scanner). The scanner is still running
+    so BlueZ stays in receive mode for the connect; the caller must stop it
+    after connecting (or on failure).
+    """
+    logger.debug("Linux: pre-scanning to keep BlueZ in receive mode for connect.")
+    found_device_holder = [None]
+    found_event = asyncio.Event()
+    def _detection_cb(device, _adv_data):
+        if device.address.upper() == bleAddr.upper() and not found_device_holder[0]:
+            found_device_holder[0] = device
+            found_event.set()
+    scanner_kwargs = {}
+    if adapter:
+        scanner_kwargs["bluez"] = {"adapter": adapter}
+    scanner = bleak.BleakScanner(detection_callback=_detection_cb, scanning_mode="active", **scanner_kwargs)
+    await scanner.start()
+    try:
+        await asyncio.wait_for(found_event.wait(), timeout=timeoutS)
+    except asyncio.TimeoutError:
+        await scanner.stop()
+        raise OSError(f"Device {bleAddr} not advertising within {timeoutS}s. Verify it's in range and powered.")
+    # Extract adapter from BlueZ device path (e.g. /org/bluez/hci1/dev_...)
+    adapter_name = None
+    details = getattr(found_device_holder[0], "details", None)
+    if isinstance(details, dict):
+        path = details.get("path") or details.get("props", {}).get("Adapter")
+        if isinstance(path, str) and "/hci" in path:
+            adapter_name = path.split("/")[3] if path.startswith("/org/bluez/") else None
+    return found_device_holder[0], adapter_name, scanner

--- a/deviceSpecific/bp4350.py
+++ b/deviceSpecific/bp4350.py
@@ -1,0 +1,15 @@
+"""Omron BP4350 (Gold Wrist) — sold in the US as HEM-6232T-Z.
+
+The trailing market letter does not change the BLE protocol, EEPROM
+layout or record format (confirmed by maintainer and verified against
+raw EEPROM dumps from hardware), so this is a thin alias for the
+existing HEM-6232T driver. The device does require an active BLE bond
+before Omron key programming succeeds; needsSmpAgent opts in to the
+Linux BlueZ bonding agent (used when pairing with --bond).
+"""
+
+hem6232t = __import__("hem-6232t")
+
+
+class deviceSpecificDriver(hem6232t.deviceSpecificDriver):
+    needsSmpAgent = True

--- a/omblepy.py
+++ b/omblepy.py
@@ -5,10 +5,13 @@ import re                                                           #regex to ma
 import argparse                                                     #to process command line arguments
 import datetime
 import sys
+import platform
 import pathlib
 import logging
 import csv
 import json
+
+import bluez_linux    #Linux/BlueZ specific workarounds, functions only called after OS check
 
 #global variables
 bleClient           = None
@@ -42,6 +45,7 @@ class bluetoothTxRxHandler:
         self.deviceUnlock_UUID          = getattr(deviceDriver, "deviceUnlock_UUID", LEGACY_DEVICE_UNLOCK_UUID)
         self.requiresUnlock             = getattr(deviceDriver, "requiresUnlock", True)
         self.supportsPairing            = getattr(deviceDriver, "supportsPairing", True)
+        self.needsSmpAgent              = getattr(deviceDriver, "needsSmpAgent", False)
         self.currentRxNotifyStateFlag   = False
         self.rxPacketType               = None
         self.rxEepromAddress            = None
@@ -232,6 +236,15 @@ class bluetoothTxRxHandler:
         if(len(newKeyByteArray) != 16):
             raise ValueError(f"key has to be 16 bytes long, is {len(newKeyByteArray)}")
 
+        # Some devices (e.g. BP4350) require BLE-level SMP pairing with a
+        # registered NoInputNoOutput agent before key programming works.
+        smp_bus = None
+        if self.needsSmpAgent and platform.system() == 'Linux':
+            smp_bus = await bluez_linux.register_smp_agent()
+            if smp_bus:
+                await bluez_linux.perform_smp_pairing(smp_bus, bleClient.address)
+                await asyncio.sleep(1.0)
+
         # Enable RX channel notifications first - this triggers the device to send
         # an SMP Security Request, which kicks off the BLE pairing process
         logger.debug("Enabling RX channel notifications to trigger pairing")
@@ -265,6 +278,8 @@ class bluetoothTxRxHandler:
             raise ValueError(f"Failure to program new key. Response: {deviceResponse}")
         await bleClient.stop_notify(self.deviceUnlock_UUID)
         await bleClient.stop_notify(self.deviceRxChannelUUIDs[0])
+        if smp_bus:
+            await bluez_linux.unregister_smp_agent(smp_bus)
         logger.info(f"Paired device successfully with new key {newKeyByteArray}.")
         logger.info("From now on you can connect omit the -p flag, even on other PCs with different bluetooth-mac-addresses.")
         return
@@ -405,46 +420,14 @@ async def main():
         print(" -do not accept any pairing dialog until you selected your device in the following list\n")
         bleAddr = await selectBLEdevices()
 
-    # Linux/BlueZ workaround: BleakClient(MAC).connect() can time out even
-    # when the device is advertising, because BlueZ's standard Connect path
-    # doesn't keep the radio actively receiving for the device. Running an
-    # active BleakScanner in parallel keeps BlueZ in receive mode, so it acts
-    # on the next advertising packet immediately. Verified empirically against
-    # an Omron BP5360 advertising every ~1.7s. Scanner is stopped in finally.
-    #
-    # Multi-adapter Linux machines also need an explicit adapter pin: BlueZ
-    # scopes the device record to whichever adapter discovered it, and a
-    # subsequent connect on a different adapter no-ops silently. We extract
-    # the adapter from the BLEDevice's BlueZ path after detection.
+    # On Linux, use an active pre-scan workaround for reliable connects
+    # (see bluez_linux.find_device_with_active_scan). Scanner is stopped in finally.
     scanner = None
     if sys.platform == "linux":
-        logger.debug("Linux: pre-scanning to keep BlueZ in receive mode for connect.")
-        found_device_holder = [None]
-        found_event = asyncio.Event()
-        def _detection_cb(device, _adv_data):
-            if device.address.upper() == bleAddr.upper() and not found_device_holder[0]:
-                found_device_holder[0] = device
-                found_event.set()
-        scanner_kwargs = {}
-        if args.adapter:
-            scanner_kwargs["bluez"] = {"adapter": args.adapter}
-        scanner = bleak.BleakScanner(detection_callback=_detection_cb, scanning_mode="active", **scanner_kwargs)
-        await scanner.start()
-        try:
-            await asyncio.wait_for(found_event.wait(), timeout=30)
-        except asyncio.TimeoutError:
-            await scanner.stop()
-            raise OSError(f"Device {bleAddr} not advertising within 30s. Verify it's in range and powered.")
-        # Extract adapter from BlueZ device path (e.g. /org/bluez/hci1/dev_...)
-        adapter_name = None
-        details = getattr(found_device_holder[0], "details", None)
-        if isinstance(details, dict):
-            path = details.get("path") or details.get("props", {}).get("Adapter")
-            if isinstance(path, str) and "/hci" in path:
-                adapter_name = path.split("/")[3] if path.startswith("/org/bluez/") else None
+        bleDevice, adapter_name, scanner = await bluez_linux.find_device_with_active_scan(bleAddr, args.adapter)
         client_kwargs = {"bluez": {"adapter": adapter_name}} if adapter_name else {}
         logger.debug(f"Connecting via adapter: {adapter_name or 'default'}")
-        bleClient = bleak.BleakClient(found_device_holder[0], **client_kwargs)
+        bleClient = bleak.BleakClient(bleDevice, **client_kwargs)
     else:
         bleClient = bleak.BleakClient(bleAddr)
 

--- a/omblepy.py
+++ b/omblepy.py
@@ -230,7 +230,7 @@ class bluetoothTxRxHandler:
         self.rxFinishedFlag = True
         return
 
-    async def writeNewUnlockKey(self, newKeyByteArray = pairingKey):
+    async def writeNewUnlockKey(self, newKeyByteArray = pairingKey, allowAutoBonding = False):
         if not self.supportsPairing:
             raise ValueError("Pairing mode is not supported for this device in omblepy.")
         if(len(newKeyByteArray) != 16):
@@ -238,12 +238,19 @@ class bluetoothTxRxHandler:
 
         # Some devices (e.g. BP4350) require BLE-level SMP pairing with a
         # registered NoInputNoOutput agent before key programming works.
+        # Because the agent accepts the bonding request without user
+        # interaction, this is only done when explicitly enabled via --bond.
         smp_bus = None
         if self.needsSmpAgent and platform.system() == 'Linux':
-            smp_bus = await bluez_linux.register_smp_agent()
-            if smp_bus:
-                await bluez_linux.perform_smp_pairing(smp_bus, bleClient.address)
-                await asyncio.sleep(1.0)
+            if allowAutoBonding:
+                smp_bus = await bluez_linux.register_smp_agent()
+                if smp_bus:
+                    await bluez_linux.perform_smp_pairing(smp_bus, bleClient.address)
+                    await asyncio.sleep(1.0)
+            else:
+                logger.warning("This device requires an active BLE bond for key programming. "
+                               "If pairing fails, either bond the device in your OS bluetooth settings first, "
+                               "or re-run with --bond to let omblepy create the bond automatically.")
 
         # Enable RX channel notifications first - this triggers the device to send
         # an SMP Security Request, which kicks off the BLE pairing process
@@ -364,6 +371,7 @@ async def main():
     parser.add_argument('-d', "--device",     required="true",  type=ascii, help="Device name (e.g. hem-7322t, see deviceSpecific folder)")
     parser.add_argument("--loggerDebug",      action="store_true",          help="Enable verbose logger output")
     parser.add_argument("-p", "--pair",       action="store_true",          help="Programm the pairing key into the device. Needs to be done only once.")
+    parser.add_argument("--bond",             action="store_true",          help="Linux/BlueZ only: allow omblepy to automatically create a BLE bond during pairing (registers a NoInputNoOutput agent that accepts the bonding request without user interaction). Required for devices like the BP4350 that only pair over an active bond. Disabled by default for security reasons.")
     parser.add_argument("-m", "--mac",                          type=ascii, help="Bluetooth Mac address of the device (e.g. 00:1b:63:84:45:e6 (win/lin) or A114A715-43E5-45A0-8683-8676EEAE885D (macOS)). If not specified, will scan for devices and display a selection dialog.")
     parser.add_argument('-n', "--newRecOnly", action="store_true",          help="Considers the unread records counter and only reads new records. Resets these counters afterwards. If not enabled, all records are read and the unread counters are not cleared.")
     parser.add_argument('-t', "--timeSync",   action="store_true",          help="Update the time on the omron device by using the current system time.")
@@ -456,7 +464,7 @@ async def main():
                              or that your OS has a bug when reading BT LE device attributes (certain linux versions).""")
         bluetoothTxRxObj = bluetoothTxRxHandler(devSpecificDriver)
         if(args.pair):
-            await bluetoothTxRxObj.writeNewUnlockKey()
+            await bluetoothTxRxObj.writeNewUnlockKey(allowAutoBonding = args.bond)
             #this seems to be necessary when the device has not been paired to any device
             await bluetoothTxRxObj.startTransmission()
             await bluetoothTxRxObj.endTransmission()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 terminaltables
 bleak
+dbus-fast; sys_platform == "linux"


### PR DESCRIPTION
### What

Adds a driver for the Omron BP4350 (Gold Wrist blood pressure monitor,
US variant of the HEM-6232T family), plus the small piece of pairing
plumbing it needs.

### Device quirks

- The BP4350 advertises OMSEC service UUIDs in its GATT table, but does
  NOT use the OMSEC ECDH protocol — it speaks the standard omblepy
  unlock-key flow (0x02/0x00/0x01 on the unlock characteristic).
- Key programming only succeeds over a bonded link. On Linux the device's
  SMP Security Request needs an agent to answer it, so this PR registers a
  temporary NoInputNoOutput BlueZ agent over D-Bus and requests pairing
  before entering key-programming mode. Uses `dbus_fast`, which is already
  a transitive dependency of bleak on Linux. Drivers opt in with a
  `needsSmpAgent = True` attribute (following the existing
  `supportsPairing` / `supportsOsBondingOnly` attribute pattern).
- The device D-Bus path is discovered via the BlueZ ObjectManager, so
  multi-adapter machines work (no hci0 assumption).

### Overlap with #71

#71 solves the same bonding problem generically (for all devices during
`-p` on Linux) and is tested on the HEM-6232T, this device's EU sibling.
If #71 lands first I'm happy to rebase: this PR would then reduce to just
the driver + README row, dropping the SMP agent code entirely.

### Safety / limitations

- Record readout and pairing verified on real hardware; the driver has
  been in daily automated use (Raspberry Pi, BlueZ) since May 2026.
- The settings EEPROM layout (unread-record counter, time sync) is NOT
  yet verified for this device, so the driver refuses `-n/--newRecOnly`
  and `-t/--timeSync` with a clear error until it's mapped. Record areas
  were verified against hardware (`0x02ae` / `0x0826`).
- Pairing on Windows/macOS is untested (the SMP agent step is
  Linux-only; other platforms fall through to the standard flow).